### PR TITLE
added progam section, moved keynote speakers, added draft for OC bios

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,5 +1,6 @@
 <ul class="links">
   <li class="{% if page.url == "/" %} active {% endif %}"><a href="{{ "/" | absolute_url }}">Home</a></li>
+  <li class="{% if page.url contains '/program/' %} active {% endif %}"><a href="{{ "/program/" | absolute_url }}">Program</a></li>
   <li class="{% if page.url contains '/about/' %} active {% endif %}"><a href="{{ "/about/" | absolute_url }}">About</a></li>
   <li class="{% if page.url contains '/coc/' %} active {% endif %}"><a href="{{ "/coc/" | absolute_url }}">Code of Conduct</a></li>
   <li class="{% if page.url contains '/faq/' %} active {% endif %}"><a href="{{ "/faq/" | absolute_url }}">FAQ</a></li>

--- a/about.md
+++ b/about.md
@@ -55,7 +55,7 @@ The names and faces of all the amazing people who make OpenCon Cascadia happen:
 - Ashley Farley / Gates 
 - Sami Friedrich / OHSU
 - Emily Ford/ Portland State
-- Lilly Winfree / OHSU - Monarch Initiative
+- Lilly Winfree / Open Knowledge International
 - Jill Emery / PSU
 - Jonathan Cain / University of Oregon Libraries
 - Asura Enkhbayar / SFU / Open Knowledge Maps

--- a/about.md
+++ b/about.md
@@ -17,46 +17,51 @@ sitemap:
 We believe that everyone has the right to access research and scholarship. We're convening OpenCon Cascadia to provide support to communities and projects with the goal of making scholarship more open, inclusive, and accessible. Are you involved in a project with a goal of improving research, academic culture, or public access to scholarly work? Are you pushing for open research at your institution or organization? Are you involved in a project that seeks to make research more accessible through citizen science or DIY science?
 Join us at OpenCon Cascadia to share stories, discuss challenges, and connect with regional colleagues in a fun and welcoming environment. We'll discuss issues facing research and scholarship today and work on strategy and communication docs for our projects.
 
-## Keynotes
-
-<div class="row keynotes">
-	<div class="image">
-		<img src="/images/keynotes/kadija-ferryman-headshot.jpg" alt="" />
-	</div>
-    <div class="text">
-        <p>Dr. Kadija Ferryman is a cultural anthropologist who studies health risk as a social, cultural, and ethical phenomenon. Specifically, her research examines the impacts of health risk prediction through information technologies such as genomics digital medical records, and artificial intelligence on marginalized groups. She is currently a Postdoctoral Scholar at the Data & Society Research Institute in New York and leads the Fairness in Precision Medicine research study, which examines the potential for bias and discrimination in predictive precision medicine. She is a Mozilla Open Science Fellow and will be conducting an ethnography examining the origins of the open health movement and the history of electronic health records during the fellowship.</p>
-    </div>
-</div>
-<hr>
-<div class="row keynotes">
-    <div class="image">
-        <img src="/images/keynotes/leslie-chan-headshot-square.png" alt="" />
-    </div>
-    <div class="text">
-        <p>Dr. Leslie Chan is an Associate Professor and Associate Director of the Centre for Critical Development Studies at the University of Toronto Scarborough. An early practitioner of the Web for scholarly and educational exchange, Leslie has been particularly interested in the role of “openness” in the design of knowledge infrastructure, and the implications on the production and flow of knowledge and their impact on local and international development. As one of the original signatories of the Budapest Open Access Initiative, Leslie has been active in the experimentation and implementation of scholarly communication initiatives of varying scales around the world. Director of Bioline International, an international collaborative open access platform, Leslie is a long time advocate for knowledge equity and inclusive development. Leslie has served as advisor to numerous projects and organizations, including the Canadian Research Knowledge Network, the American Anthropological Association, the International Development Research Centre, UNESCO, the Open Society Foundation, the Directory of Open Access Journal, more recently the San Francisco Declaration on Research Assessment (DORA). Leslie is the principal investigator for the Open and Collaborative Science in Development Network (OCSDNet), funded by IDRC in Canada and DFID in the UK, and the PI of the Knowledge G.A.P project.</p>
-    </div>
-</div>
-
 ## Sponsors
 
 Help make OpenCon Cascadia great! We are looking for sponsors to keep our event *low cost to attend* and to fund:<br>
 Lunch - Coffee breaks - Childcare - AV Support - First-rate speakers - Free tickets
 
 ### Gold Sponsor: $2500+
+
 - Exclusive sponsorship of lunch with signage
 - 10-minute speaking opportunity
 - Logo on our website, fliers, and promotional material
 - Recognition during conference opening remarks
 
 ### Silver Sponsor: $1500-2499
+
 - Exclusive sponsorship of a coffee break with signage
 - 5-minute speaking opportunity
 - Logo on our website, fliers, and promotional material
 - Recognition during conference opening remarks
 
 ### Bronze Sponsor: $500-1499
+
 - Logo on our website, fliers, and promotional material
 - Recognition during conference opening remarks
 
 Interested in becoming a sponsor? Please email us at [openconcascadia@gmail.com](mailto:openconcascadia@gmail.com)!
+
+## The Organizing Committee
+
+The names and faces of all the amazing people who make OpenCon Cascadia happen:
+
+- Daniela Saderi / OHSU / PREreview
+- Pam Pierce / OHSU
+- Robin Champieux / OHSU 
+- Luci Moore / OHSU
+- Danielle Robinson / Code for Science & Society
+- Ashley Farley / Gates 
+- Sami Friedrich / OHSU
+- Emily Ford/ Portland State
+- Lilly Winfree / OHSU - Monarch Initiative
+- Jill Emery / PSU
+- Jonathan Cain / University of Oregon Libraries
+- Asura Enkhbayar / SFU / Open Knowledge Maps
+- David Isaak / Reed College
+- Olivia Hancock/OHSU
+- Clara Llebot / Oregon State University
+- Leila Sterman / Montana State
+- Theresa Cheng / University of Oregon
 

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@ changefreq: weekly
 					</div>
 				</div>
 
-				<div>You can find more information about both speakers on our <a href="/about#keynotes">About</a> page.</div>
+				<div>You can find more information about both speakers in our <a href="/program#keynote-speakers">program</a>.</div>
 
 			</div>
 				

--- a/program.md
+++ b/program.md
@@ -1,0 +1,37 @@
+---
+layout: page
+title: Conference Program
+description: Conference Program
+sitemap:
+    priority: 0.7
+    lastmod: 2018-11-07
+    changefreq: weekly
+---
+
+## Program
+
+Stay tuned for more information!
+
+### Keynote Speakers
+
+<div class="row keynotes">
+	<div class="image">
+		<img src="/images/keynotes/kadija-ferryman-headshot.jpg" alt="" />
+	</div>
+    <div class="text">
+        <p>Dr. Kadija Ferryman is a cultural anthropologist who studies health risk as a social, cultural, and ethical phenomenon. Specifically, her research examines the impacts of health risk prediction through information technologies such as genomics digital medical records, and artificial intelligence on marginalized groups. She is currently a Postdoctoral Scholar at the Data & Society Research Institute in New York and leads the Fairness in Precision Medicine research study, which examines the potential for bias and discrimination in predictive precision medicine. She is a Mozilla Open Science Fellow and will be conducting an ethnography examining the origins of the open health movement and the history of electronic health records during the fellowship.</p>
+    </div>
+</div>
+<hr>
+<div class="row keynotes">
+    <div class="image">
+        <img src="/images/keynotes/leslie-chan-headshot-square.png" alt="" />
+    </div>
+    <div class="text">
+        <p>Dr. Leslie Chan is an Associate Professor and Associate Director of the Centre for Critical Development Studies at the University of Toronto Scarborough. An early practitioner of the Web for scholarly and educational exchange, Leslie has been particularly interested in the role of “openness” in the design of knowledge infrastructure, and the implications on the production and flow of knowledge and their impact on local and international development. As one of the original signatories of the Budapest Open Access Initiative, Leslie has been active in the experimentation and implementation of scholarly communication initiatives of varying scales around the world. Director of Bioline International, an international collaborative open access platform, Leslie is a long time advocate for knowledge equity and inclusive development. Leslie has served as advisor to numerous projects and organizations, including the Canadian Research Knowledge Network, the American Anthropological Association, the International Development Research Centre, UNESCO, the Open Society Foundation, the Directory of Open Access Journal, more recently the San Francisco Declaration on Research Assessment (DORA). Leslie is the principal investigator for the Open and Collaborative Science in Development Network (OCSDNet), funded by IDRC in Canada and DFID in the UK, and the PI of the Knowledge G.A.P project.</p>
+    </div>
+</div>
+
+### Schedule
+
+_TBD_


### PR DESCRIPTION
Related to issue #25 

Changes:

- Added a program section
- Moved keynote speakers details from `about` to `program`
- Created a draft for the OC bios

Need feedback:

Is the list of OC members complete? I went through the organising doc and added names from all calls. Will reformat later and make nicer once names/faces are complete.